### PR TITLE
Only add auth headers to ntfy.sh when set

### DIFF
--- a/notification/ntfy.go
+++ b/notification/ntfy.go
@@ -26,13 +26,21 @@ func (c NtfyClient) SendTicketNotification(ticket twigots.TicketListing) error {
 		return err
 	}
 
-	_, err = c.client.Publish(
-		c.url.String(),
-		notificationMessage,
+	opts := []client.PublishOption{
 		client.WithTitle(ticket.Event.Name),
 		client.WithActions(NtfyViewAction("Open Link", lo.ToPtr(ticket.URL()))),
 		client.WithHeader("Content-Type", "text/markdown"),
-		client.WithBasicAuth(c.user, c.password),
+	}
+	// If you try to set any auth on an unprotected topic, it will fail
+	//  so only set it if the user and password are set
+	if c.user != "" && c.password != "" {
+		opts = append(opts, client.WithBasicAuth(c.user, c.password))
+	}
+
+	_, err = c.client.Publish(
+		c.url.String(),
+		notificationMessage,
+		opts...,
 	)
 	if err != nil {
 		return err

--- a/notification/ntfy_test.go
+++ b/notification/ntfy_test.go
@@ -39,3 +39,27 @@ func TestNtfySendTicketMessage(t *testing.T) {
 	err = client.SendTicketNotification(ticket)
 	require.NoError(t, err)
 }
+
+func TestNtfySendTicketMessageWithoutAuth(t *testing.T) {
+	t.Skip("Can only be run manually locally with environment variables set. Comment to run.")
+
+	_ = godotenv.Load(test.ProjectDirectoryJoin(t, ".env"))
+
+	ntfyUrl := os.Getenv("NTFY_URL")
+	require.NotEmpty(t, ntfyUrl, "NTFY_URL is not set")
+
+	ntfyUser := os.Getenv("NTFY_USER")
+	require.NotEmpty(t, ntfyUser, "NTFY_USER is not set")
+
+	client, err := notification.NewNtfyClient(notification.NtfyConfig{
+		Url:      ntfyUrl,
+		Username: ntfyUser,
+		Password: "",
+		Topic:    "",
+	})
+	require.NoError(t, err)
+
+	ticket := testNotificationTicket()
+	err = client.SendTicketNotification(ticket)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
My current deployment is failing, with errors in the logs of

```
2025/05/21 17:59:28 ERROR Failed to send notification err="{\"code\":40101,\"http\":401,\"error\":\"unauthorized\",\"link\":\"https://ntfy.sh/docs/publish/#authentication\"}"
```

Looking at ntfy's issues, it appears that this can happen when the client tries to set auth on an unprotected topic (my topic currently is unprotected - there's nothing confidential in the messages)

I took a quick hack at adjusting the code to support this and added a test. 

Please be kind - this is my first Golang thing, and **I have not built the entire app and tried running it with this config** - I've only added (and run) the extra test.

