### PR TITLE
Include the event that was matched in the logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func fetchAndProcessTickets(
 		for _, listing := range filteredListings {
 			slog.Info(
 				"Found tickets for monitored event",
+				"configEvent", ticketConfig.Event,
 				"eventName", listing.Event.Name,
 				"numTickets", listing.NumTickets,
 				"ticketPrice", listing.TotalPriceInclFee().String(),


### PR DESCRIPTION
I've been playing around with the `eventSimilarity` values, and started getting some slightly wacky matches. It would be so helpful for me if I could see in the logs which of my events triggered the match!