### PR TITLE
Print (combined) config in more easily readable form on start

### DIFF
--- a/config/print.go
+++ b/config/print.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+func PrintTicketListingConfigs(configs []TicketListingConfig) {
+	fmt.Println("Config:")
+	fmt.Println()
+	for _, config := range configs {
+		PrintTicketListingConfig(config)
+		fmt.Println()
+	}
+}
+
+func PrintTicketListingConfig(config TicketListingConfig) {
+	fmt.Printf("Event: %s\n", config.Event)
+	if config.EventSimilarity == nil || *config.EventSimilarity <= 0.0 {
+		fmt.Println("Event Similarity: Default (0.9)")
+	} else {
+		fmt.Printf("Event Similarity: %.2f%%\n", *config.EventSimilarity*100)
+	}
+
+	if len(config.Regions) == 0 {
+		fmt.Println("Regions: Any")
+	} else {
+
+		// Get regions as a string
+		regionStrings := make([]string, 0, len(config.Regions))
+		for _, region := range config.Regions {
+			regionStrings = append(regionStrings, region.Value)
+		}
+		regionsString := strings.Join(regionStrings, ", ")
+
+		fmt.Printf("Regions: %s\n", regionsString)
+	}
+
+	if config.NumTickets == nil {
+		fmt.Println("Number of Tickets: Any")
+	} else {
+		fmt.Printf("Number of Tickets: %d\n", *config.NumTickets)
+	}
+
+	if config.Discount == nil || *config.Discount <= 0.0 {
+		fmt.Println("Discount: Any")
+	} else {
+		fmt.Printf("Discount: %.0f%%\n", *config.Discount)
+	}
+
+	if len(config.Notification) == 0 {
+		fmt.Println("Notification Types: All")
+	} else {
+
+		// Get notifications as a string
+		notificationStrings := make([]string, 0, len(config.Notification))
+		for _, notification := range config.Notification {
+			notificationStrings = append(notificationStrings, notification.Value)
+		}
+		notificationsString := strings.Join(notificationStrings, ", ")
+
+		fmt.Printf("Notifications: %s\n", notificationsString)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"log/slog"
 	"math"
@@ -58,14 +57,8 @@ func main() {
 	// Get combined ticket listing configs
 	listingConfigs := conf.CombinedTicketListingConfigs()
 
-	// Event names
-	eventNames := make([]string, 0, len(conf.TicketConfigs))
-	for _, event := range conf.TicketConfigs {
-		eventNames = append(eventNames, event.Event)
-	}
-	slog.Info(
-		fmt.Sprintf("Monitoring: %s", strings.Join(eventNames, ", ")),
-	)
+	// Print config
+	config.PrintTicketListingConfigs(listingConfigs)
 
 	// Initial execution
 	fetchAndProcessTickets(client, notificationClients, listingConfigs)


### PR DESCRIPTION
Currently we just print all event name in one long comma-delimited list. This make it hard to see what the actual config being used is. 

This PR actually prints the all the (combined) ticket config in an easily readable format.