### PR TITLE
Fix enum marshalling

### DIFF
--- a/config/notification.go
+++ b/config/notification.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 )
 
+func (c *NotificationType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Value)
+}
+
 func (c *NotificationType) UnmarshalJSON(data []byte) error {
 	var notificationTypeString string
 	err := json.Unmarshal(data, &notificationTypeString)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ tool (
 )
 
 require (
-	github.com/ahobsonsayers/twigots v0.6.0
+	github.com/ahobsonsayers/twigots v0.6.1
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/httplog/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/OpenPeeDeeP/depguard/v2 v2.2.1 h1:vckeWVESWp6Qog7UZSARNqfu/cZqvki8zsu
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1/go.mod h1:q4DKzC4UcVaAvcfd41CZh0PWpGgzrVxUYBlgKNGquUo=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/ahobsonsayers/twigots v0.6.0 h1:ptydB0KNmoMw6BEViv0Yw242v/Hc0/79g0vPe5wtOnA=
-github.com/ahobsonsayers/twigots v0.6.0/go.mod h1:wTPdT/x3f2T0LORMFencbqKkfdbyHa+icmNGXrFiog8=
+github.com/ahobsonsayers/twigots v0.6.1 h1:SrXrniPCPpvX+uaaFN//r4qKMvkFAawVjgUmBjzEEj4=
+github.com/ahobsonsayers/twigots v0.6.1/go.mod h1:wTPdT/x3f2T0LORMFencbqKkfdbyHa+icmNGXrFiog8=
 github.com/ahobsonsayers/utilopia v0.2.1 h1:oRuBxIX2Z7/VQud7Y2zLLaCzOUbV6Ip7LEIpjNAke5c=
 github.com/ahobsonsayers/utilopia v0.2.1/go.mod h1:AukMK2ripr9bAUHlDaQW4yTtkXUsUqNjCxy8yQDJWbo=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=


### PR DESCRIPTION
Fix enum marshalling by update twigots and adding custom `MarshalJSON` for notification types